### PR TITLE
Possible typos in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ fit_noZI<-twosigma(count=counts,zi_covar=0,mean_covar = X,id=id,mean_re=F,zi_re=
 fit_noZ2I<-twosigma_custom(count=counts,zi_form=~0,mean_form=count~X,id=id)
 #--- Fit TWO-SIGMA with an intercept only zero-inflation component and no random effects
 fit_meanZI<-twosigma(count=counts,zi_covar=1,mean_covar = X,id=id,mean_re=F,zi_re=F,adhoc=F)
-fit_meanZI2<-twosigma_custom(count=counts, mean_form=count~X+(1|id),zi_form=~1,id=id)
+fit_meanZI2<-twosigma_custom(count=counts, mean_form=count~X,zi_form=~1,id=id)
 
 summary(fit_noZI)
 summary(fit_meanZI)


### PR DESCRIPTION
Hi @edvanburen ,

I think in your README tutorial, for the "Fit TWO-SIGMA with an intercept only zero-inflation component and no random effects". The correct formula should be
`fit_meanZI2<-twosigma_custom(count=counts, mean_form=count~X,zi_form=~1,id=id)`
right? Thanks.